### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/index.php
+++ b/index.php
@@ -319,7 +319,7 @@ function display_record_summary ($reference, $highlights = null)
 						break;
 						
 					case 'doi':
-						echo ' <span class="doi"><a href="http://dx.doi.org/' . $identifier->id . '" target="_new">' . $identifier->id . '</a></span>' . '<br />';
+						echo ' <span class="doi"><a href="https://doi.org/' . $identifier->id . '" target="_new">' . $identifier->id . '</a></span>' . '<br />';
 						break;
 
 					case 'jstor':
@@ -523,7 +523,7 @@ function display_article_metadata($reference)
 					break;			
 			
 				case 'doi':
-					echo '<span class="doi"><a href="http://dx.doi.org/' . $identifier->id . '" target="_new">' . $identifier->id  . '</a></span>';
+					echo '<span class="doi"><a href="https://doi.org/' . $identifier->id . '" target="_new">' . $identifier->id  . '</a></span>';
 					echo '<br />';
 					break;
 					


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old links with the `dx` subdomain continue to work.

So, there is no urgent need to do anything, but nonetheless, I'd like to suggest to hereby update any code that hyperlinks DOIs.

Cheers!